### PR TITLE
feat: add support for direct connections

### DIFF
--- a/include/sdbus-c++/IConnection.h
+++ b/include/sdbus-c++/IConnection.h
@@ -458,6 +458,24 @@ namespace sdbus {
      * @throws sdbus::Error in case of failure
      */
     [[nodiscard]] std::unique_ptr<sdbus::IConnection> createRemoteSystemBusConnection(const std::string& host);
+
+    /*!
+     * @brief Opens direct D-Bus connection at a custom address
+     *
+     * @param[in] address ";"-separated kist of addresses of sockets toinstance
+     *
+     * @throws sdbus::Error in case of failure
+     */
+    [[nodiscard]] std::unique_ptr<sdbus::IConnection> createDirectBusConnection(const std::string &address);
+
+    /*!
+     * @brief Opens direct D-Bus connection at fd
+     *
+     * @param[in] fd file desctiptor to use for DBus connection. Caller owns the fd so its caller response to close it.
+     *
+     * @throws sdbus::Error in case of failure
+     */
+    [[nodiscard]] std::unique_ptr<sdbus::IConnection> createServerBus(int fd);
 }
 
 #endif /* SDBUS_CXX_ICONNECTION_H_ */

--- a/include/sdbus-c++/IProxy.h
+++ b/include/sdbus-c++/IProxy.h
@@ -474,6 +474,27 @@ namespace sdbus {
                                                             , std::string objectPath );
 
     /*!
+     * @brief Creates a proxy object for a direct connection to the DBus server
+     *
+     * @param[in] connection D-Bus connection to be used by the proxy object
+     * @param[in] objectPath Path of the remote D-Bus object
+     * @return Pointer to the proxy object instance
+     *
+     * The provided connection will be used by the proxy to issue calls against the object,
+     * and signals, if any, will be subscribed to on this connection. The caller still
+     * remains the owner of the connection (the proxy just keeps a reference to it), and
+     * should make sure that an I/O event loop is running on that connection, so the proxy
+     * may receive incoming signals and asynchronous method replies.
+     *
+     * Code example:
+     * @code
+     * auto proxy = sdbus::createProxy(connection, "/com/kistler/foo");
+     * @endcode
+     */
+    [[nodiscard]] std::unique_ptr<sdbus::IProxy> createProxy( sdbus::IConnection& connection
+                                                            , std::string objectPath );
+
+	/*!
      * @brief Creates a proxy object for a specific remote D-Bus object
      *
      * @param[in] connection D-Bus connection to be used by the proxy object
@@ -497,6 +518,28 @@ namespace sdbus {
                                                             , std::string objectPath );
 
     /*!
+     * @brief Creates a proxy object for a direct connection to the DBus server
+     *
+     * @param[in] connection D-Bus connection to be used by the proxy object
+     * @param[in] objectPath Path of the remote D-Bus object
+     * @return Pointer to the object proxy instance
+     *
+     * The provided connection will be used by the proxy to issue calls against the object,
+     * and signals, if any, will be subscribed to on this connection. The Object proxy becomes
+     * an exclusive owner of this connection, and will automatically start a procesing loop
+     * upon that connection in a separate internal thread. Handlers for incoming signals and
+     * asynchronous method replies will be executed in the context of that thread.
+     *
+     * Code example:
+     * @code
+     * auto proxy = sdbus::createProxy(std::move(connection), "/com/kistler/foo");
+     * @endcode
+     */
+    [[nodiscard]] std::unique_ptr<sdbus::IProxy> createProxy( std::unique_ptr<sdbus::IConnection>&& connection
+                                                            , std::string objectPath );
+
+
+	/*!
      * @brief Creates a proxy object for a specific remote D-Bus object
      *
      * @param[in] connection D-Bus connection to be used by the proxy object
@@ -521,6 +564,28 @@ namespace sdbus {
                                                             , dont_run_event_loop_thread_t );
 
     /*!
+     * @brief Creates a proxy object for a direct connection to the DBus server
+     *
+     * @param[in] connection D-Bus connection to be used by the proxy object
+     * @param[in] objectPath Path of the remote D-Bus object
+     * @return Pointer to the object proxy instance
+     *
+     * The provided connection will be used by the proxy to issue calls against the object.
+     * The Object proxy becomes an exclusive owner of this connection, but will not start an event loop
+     * thread on this connection. This is cheap construction and is suitable for short-lived proxies
+     * created just to execute simple synchronous D-Bus calls and then destroyed. Such blocking request-reply
+     * calls will work without an event loop (but signals, async calls, etc. won't).
+     *
+     * Code example:
+     * @code
+     * auto proxy = sdbus::createProxy(std::move(connection), "/com/kistler/foo", sdbus::dont_run_event_loop_thread);
+     * @endcode
+     */
+    [[nodiscard]] std::unique_ptr<sdbus::IProxy> createProxy( std::unique_ptr<sdbus::IConnection>&& connection
+                                                            , std::string objectPath
+                                                            , dont_run_event_loop_thread_t );
+
+	/*!
      * @brief Creates a proxy object for a specific remote D-Bus object
      *
      * @param[in] destination Bus name that provides the remote D-Bus object

--- a/src/Connection.h
+++ b/src/Connection.h
@@ -57,6 +57,10 @@ namespace sdbus::internal {
         inline static constexpr custom_session_bus_t custom_session_bus{};
         struct remote_system_bus_t{};
         inline static constexpr remote_system_bus_t remote_system_bus{};
+        struct private_bus_t{};
+        inline static constexpr private_bus_t private_bus{};
+        struct server_bus_t{};
+        inline static constexpr server_bus_t server_bus{};
         struct pseudo_bus_t{}; // A bus connection that is not really established with D-Bus daemon
         inline static constexpr pseudo_bus_t pseudo_bus{};
 
@@ -65,6 +69,8 @@ namespace sdbus::internal {
         Connection(std::unique_ptr<ISdBus>&& interface, session_bus_t);
         Connection(std::unique_ptr<ISdBus>&& interface, custom_session_bus_t, const std::string& address);
         Connection(std::unique_ptr<ISdBus>&& interface, remote_system_bus_t, const std::string& host);
+        Connection(std::unique_ptr<ISdBus>&& interface, private_bus_t, const std::string& address);
+        Connection(std::unique_ptr<ISdBus>&& interface, server_bus_t, int fd);
         Connection(std::unique_ptr<ISdBus>&& interface, pseudo_bus_t);
         ~Connection() override;
 
@@ -96,7 +102,7 @@ namespace sdbus::internal {
                             , void* userData ) override;
 
         PlainMessage createPlainMessage() const override;
-        MethodCall createMethodCall( const std::string& destination
+        MethodCall createMethodCall( const std::optional<std::string>& destination
                                    , const std::string& objectPath
                                    , const std::string& interfaceName
                                    , const std::string& methodName ) const override;
@@ -114,7 +120,7 @@ namespace sdbus::internal {
         void emitInterfacesRemovedSignal( const std::string& objectPath
                                         , const std::vector<std::string>& interfaces ) override;
 
-        Slot registerSignalHandler( const std::string& sender
+        Slot registerSignalHandler( const std::optional<std::string>& sender
                                   , const std::string& objectPath
                                   , const std::string& interfaceName
                                   , const std::string& signalName
@@ -132,7 +138,7 @@ namespace sdbus::internal {
         BusPtr openPseudoBus();
         void finishHandshake(sd_bus* bus);
         bool waitForNextRequest();
-        static std::string composeSignalMatchFilter( const std::string &sender
+        static std::string composeSignalMatchFilter( const std::optional<std::string>& sender
                                                    , const std::string &objectPath
                                                    , const std::string &interfaceName
                                                    , const std::string &signalName);

--- a/src/IConnection.h
+++ b/src/IConnection.h
@@ -62,7 +62,7 @@ namespace sdbus::internal {
                                                   , void* userData ) = 0;
 
         virtual PlainMessage createPlainMessage() const = 0;
-        virtual MethodCall createMethodCall( const std::string& destination
+        virtual MethodCall createMethodCall( const std::optional<std::string>& destination
                                            , const std::string& objectPath
                                            , const std::string& interfaceName
                                            , const std::string& methodName ) const = 0;
@@ -83,7 +83,7 @@ namespace sdbus::internal {
         using sdbus::IConnection::addObjectManager;
         [[nodiscard]] virtual Slot addObjectManager(const std::string& objectPath, request_slot_t) = 0;
 
-        [[nodiscard]] virtual Slot registerSignalHandler( const std::string& sender
+        [[nodiscard]] virtual Slot registerSignalHandler( const std::optional<std::string>& sender
                                                         , const std::string& objectPath
                                                         , const std::string& interfaceName
                                                         , const std::string& signalName

--- a/src/ISdBus.h
+++ b/src/ISdBus.h
@@ -71,6 +71,8 @@ namespace sdbus::internal {
         virtual int sd_bus_open_user(sd_bus **ret) = 0;
         virtual int sd_bus_open_user_with_address(sd_bus **ret, const char* address) = 0;
         virtual int sd_bus_open_system_remote(sd_bus **ret, const char* host) = 0;
+        virtual int sd_bus_open_direct(sd_bus **ret, const char* address) = 0;
+        virtual int sd_bus_open_server(sd_bus **ret, int fd) = 0;
         virtual int sd_bus_request_name(sd_bus *bus, const char *name, uint64_t flags) = 0;
         virtual int sd_bus_release_name(sd_bus *bus, const char *name) = 0;
         virtual int sd_bus_get_unique_name(sd_bus *bus, const char **name) = 0;

--- a/src/Proxy.h
+++ b/src/Proxy.h
@@ -45,13 +45,13 @@ namespace sdbus::internal {
     {
     public:
         Proxy( sdbus::internal::IConnection& connection
-             , std::string destination
+             , std::optional<std::string> destination
              , std::string objectPath );
         Proxy( std::unique_ptr<sdbus::internal::IConnection>&& connection
-             , std::string destination
+             , std::optional<std::string> destination
              , std::string objectPath );
         Proxy( std::unique_ptr<sdbus::internal::IConnection>&& connection
-             , std::string destination
+             , std::optional<std::string> destination
              , std::string objectPath
              , dont_run_event_loop_thread_t );
 
@@ -100,7 +100,7 @@ namespace sdbus::internal {
         std::unique_ptr< sdbus::internal::IConnection
                        , std::function<void(sdbus::internal::IConnection*)>
                        > connection_;
-        std::string destination_;
+        std::optional<std::string> destination_;
         std::string objectPath_;
 
         using InterfaceName = std::string;

--- a/src/SdBus.cpp
+++ b/src/SdBus.cpp
@@ -222,6 +222,57 @@ int SdBus::sd_bus_open_user_with_address(sd_bus **ret, const char* address)
     return 0;
 }
 
+int SdBus::sd_bus_open_direct(sd_bus **ret, const char* address)
+{
+    sd_bus* bus = nullptr;
+
+    int r = sd_bus_new(&bus);
+    if (r < 0)
+        return r;
+
+    r = sd_bus_set_address(bus, address);
+    if (r < 0)
+        return r;
+
+    r = sd_bus_start(bus);
+    if (r < 0)
+        return r;
+
+    *ret = bus;
+
+    return 0;
+}
+
+int SdBus::sd_bus_open_server(sd_bus **ret, int fd)
+{
+    sd_bus* bus = nullptr;
+
+    int r = sd_bus_new(&bus);
+    if (r < 0)
+        return r;
+
+    r = ::sd_bus_set_fd(bus, fd, fd);
+    if (r < 0)
+        return r;
+
+    sd_id128_t id;
+    r = ::sd_id128_randomize(&id);
+    if (r < 0)
+        return r;
+
+    r = ::sd_bus_set_server(bus, true, id);
+    if (r < 0)
+        return r;
+
+    r = sd_bus_start(bus);
+    if (r < 0)
+        return r;
+
+    *ret = bus;
+
+    return 0;
+}
+
 int SdBus::sd_bus_open_system_remote(sd_bus **ret, const char *host)
 {
     return ::sd_bus_open_system_remote(ret, host);

--- a/src/SdBus.h
+++ b/src/SdBus.h
@@ -63,6 +63,8 @@ public:
     virtual int sd_bus_open_user(sd_bus **ret) override;
     virtual int sd_bus_open_user_with_address(sd_bus **ret, const char* address) override;
     virtual int sd_bus_open_system_remote(sd_bus **ret, const char* hsot) override;
+    virtual int sd_bus_open_direct(sd_bus **ret, const char* address) override;
+    virtual int sd_bus_open_server(sd_bus **ret, int fd) override;
     virtual int sd_bus_request_name(sd_bus *bus, const char *name, uint64_t flags) override;
     virtual int sd_bus_release_name(sd_bus *bus, const char *name) override;
     virtual int sd_bus_get_unique_name(sd_bus *bus, const char **name) override;

--- a/tests/unittests/mocks/SdBusMock.h
+++ b/tests/unittests/mocks/SdBusMock.h
@@ -62,6 +62,8 @@ public:
     MOCK_METHOD1(sd_bus_open_user, int(sd_bus **ret));
     MOCK_METHOD2(sd_bus_open_user_with_address, int(sd_bus **ret, const char* address));
     MOCK_METHOD2(sd_bus_open_system_remote, int(sd_bus **ret, const char *host));
+    MOCK_METHOD2(sd_bus_open_direct, int(sd_bus **ret, const char* address));
+    MOCK_METHOD2(sd_bus_open_server, int(sd_bus **ret, int fd));
     MOCK_METHOD3(sd_bus_request_name, int(sd_bus *bus, const char *name, uint64_t flags));
     MOCK_METHOD2(sd_bus_release_name, int(sd_bus *bus, const char *name));
     MOCK_METHOD2(sd_bus_get_unique_name, int(sd_bus *bus, const char **name));


### PR DESCRIPTION
Hi there!

This commit adds support for create direct connections with sdbus-cpp.

There is a design issue over which i though for a while. In other libraries for DBus such as `libdbus`, `QtDBus`, `GDBus` exists entity `DBusServer` that provide functionality for creating direct connections. User specify only address with desired transport (https://dbus.freedesktop.org/doc/dbus-specification.html#Transports). But in `sdbus` there is no such convenient entity and user have to create listening server by his own. He needs to create bus with `sd_bus_new` and then configure that bus with  `sd_bus_set_fd` call, when `fd` is the file descriptor for separate connection (returned by the  `accept` syscall, for instance). Examples can be found here https://www.spinics.net/lists/systemd-devel/msg01558.html. I decided to follow their path and leave the responsibility of creating a listening socket to user.

I tried to found a way to provide convenient `DBusServer` class. But such class requires an general event loop in which to be integrated. Event loop in `Connection` class not suitable, because it polling it's own `sd_bus` bus.

There also a way to create api method `[[nodiscard]] std::unique_ptr<sdbus::IConnection> createServerBus(const std::string &address)` where user can pass address with desired transport. But this method must block until client connect, because in other way `BusPtr` inside it will be invalid until client connected and `sd_bus_start` called.